### PR TITLE
Templates to validate pass/fail of the 'deny-unrestricted-access' policy

### DIFF
--- a/definitions/tests/Microsoft.Storage/deny-unrestricted-access/fail.default-action-allow.json
+++ b/definitions/tests/Microsoft.Storage/deny-unrestricted-access/fail.default-action-allow.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "testName": {
+            "type": "string",
+            "defaultValue": "insecure-transfer-allowed"
+        }
+    },
+    "variables": {
+        "nameSeed": "[concat(resourceGroup().id, parameters('testName'))]",
+        "storageAccountName": "[take(uniqueString(variables('nameSeed')), 24)]"
+    },
+    "resources": [
+        {
+            "apiVersion": "2018-07-01",
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[variables('storageAccountName')]",
+            "location": "[resourceGroup().location]",
+            "kind": "Storage",
+            "sku": {
+                "name": "Standard_LRS"
+            },
+            "properties": {
+                "networkAcls": {
+                    "defaultAction": "Allow"
+                }
+            }
+        }
+    ],
+    "outputs": {}
+}

--- a/definitions/tests/Microsoft.Storage/deny-unrestricted-access/pass.default-action-deny.json
+++ b/definitions/tests/Microsoft.Storage/deny-unrestricted-access/pass.default-action-deny.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "testName": {
+            "type": "string",
+            "defaultValue": "secure-transfer-enabled"
+        }
+    },
+    "variables": {
+        "nameSeed": "[concat(resourceGroup().id, parameters('testName'))]",
+        "storageAccountName": "[take(uniqueString(variables('nameSeed')), 24)]"
+    },
+    "resources": [
+        {
+            "apiVersion": "2018-07-01",
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[variables('storageAccountName')]",
+            "location": "[resourceGroup().location]",
+            "kind": "Storage",
+            "sku": {
+                "name": "Standard_LRS"
+            },
+            "properties": {
+                "networkAcls": {
+                    "defaultAction": "Deny"
+                }
+            }
+        }
+    ],
+    "outputs": {}
+}


### PR DESCRIPTION
Super simple to start

* Put things in `definitions/tests` & following folder convention in the repo
* Naming convention for `pass`/`fail` instead of extra config files

I tested this manually with armclient-go + az cli. Didn't want to check in any of my scripts into the repo - will translate these ideas to Python when we have basic auth bits.

```bash
# create the assignment
~/armclient put '/subscriptions/6c1f4f3b-f65f-4667-8f9e-b9c48e09cd6b/providers/Microsoft.Authorization/policyDefinitions/deny-unrestricted-access?api-version=2016-12-01' @definitions/Microsoft.Storage/deny-unrestricted-access.json

# create the test sandbox (resource group + assignment)
RG_ID=$(az group create -n policytest -l westus2 --query id -o tsv)
az policy assignment create --policy '/subscriptions/6c1f4f3b-f65f-4667-8f9e-b9c48e09cd6b/providers/Microsoft.Authorization/policyDefinitions/deny-unrestricted-access' --scope $RG_ID

# deploy negative templates (these should fail)
az group deployment create -g policytest --template-file definitions/tests/Microsoft.Storage/deny-unrestricted-access/fail.default-action-allow.json

# deploy positive templates (these should pass and create resources)
az group deployment create -g policytest --template-file definitions/tests/Microsoft.Storage/deny-unrestricted-access/pass.default-action-deny.json

# teardown
az group delete -n policytest -y --no-wait
```

Works great - got an expected passing result & a rejected deployment
![image](https://user-images.githubusercontent.com/1970162/52372106-2299f500-2a0c-11e9-81f2-92d4682cd9f1.png)

